### PR TITLE
fix: implement ForTag.children()

### DIFF
--- a/liquid_jsonpath/tags/for_tag.py
+++ b/liquid_jsonpath/tags/for_tag.py
@@ -104,7 +104,8 @@ class JSONPathExpression(Expression):
 
     def children(self) -> List[Expression]:
         """Return a list of child expressions."""
-        # TODO: inspect self.path for FilterContextPath expressions
+        # XXX: We can't inspect self.path statically, because we can't get a
+        # normalized JSONPath query without some data to apply the query to.
         return [self.expression]
 
 

--- a/liquid_jsonpath/tags/for_tag.py
+++ b/liquid_jsonpath/tags/for_tag.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
@@ -100,6 +101,11 @@ class JSONPathExpression(Expression):
 
         msg = f"expected a sequence or mapping, found {obj.__class__.__name__}"
         raise LiquidTypeError(msg)
+
+    def children(self) -> List[Expression]:
+        """Return a list of child expressions."""
+        # TODO: inspect self.path for FilterContextPath expressions
+        return [self.expression]
 
 
 class JSONPathForTag(ForTag):

--- a/tests/test_find_filter.py
+++ b/tests/test_find_filter.py
@@ -151,8 +151,8 @@ def test_string_left_empty_default() -> None:
     async def coro() -> str:
         return await template.render_async(data=data)
 
-    assert template.render(data=data) == ""  # noqa: PLC1901
-    assert asyncio.run(coro()) == ""  # noqa: PLC1901
+    assert template.render(data=data) == ""
+    assert asyncio.run(coro()) == ""
 
 
 def test_int_left_empty_default() -> None:
@@ -163,8 +163,8 @@ def test_int_left_empty_default() -> None:
     async def coro() -> str:
         return await template.render_async(data=data)
 
-    assert template.render(data=data) == ""  # noqa: PLC1901
-    assert asyncio.run(coro()) == ""  # noqa: PLC1901
+    assert template.render(data=data) == ""
+    assert asyncio.run(coro()) == ""
 
 
 def test_invalid_path_empty_default(data: Mapping[str, object]) -> None:
@@ -175,8 +175,8 @@ def test_invalid_path_empty_default(data: Mapping[str, object]) -> None:
     async def coro() -> str:
         return await template.render_async(data=data)
 
-    assert template.render(data=data) == ""  # noqa: PLC1901
-    assert asyncio.run(coro()) == ""  # noqa: PLC1901
+    assert template.render(data=data) == ""
+    assert asyncio.run(coro()) == ""
 
 
 def test_extra_find_filter_context(data: Mapping[str, object]) -> None:

--- a/tests/test_for_tag.py
+++ b/tests/test_for_tag.py
@@ -234,3 +234,19 @@ def test_size_of_filter_context(data: Mapping[str, object]) -> None:
         return await template.render_async(data=data)
 
     assert asyncio.run(coro()) == "Sue, John, Sally, Jane, "
+
+
+def test_jsonpath_for_tag() -> None:
+    env = Environment()
+    env.add_tag(JSONPathForTag)
+    template = env.from_string(
+        "{% for name in data | '$.users[?@.name in _.names].name' %}"
+        "{{ name }}, "
+        "{% endfor %}",
+        globals={"names": ["Sue", "Sally"]},
+    )
+
+    analysis = template.analyze()
+    assert analysis.variables == {"data": [("<string>", 1)], "name": [("<string>", 1)]}
+    assert analysis.global_variables == {"data": [("<string>", 1)]}
+    assert analysis.tags == {"for": [("<string>", 1)]}

--- a/tests/test_for_tag.py
+++ b/tests/test_for_tag.py
@@ -143,12 +143,12 @@ def test_target_string_empty_default() -> None:
         "{% for name in 'foo' | '$.users.*.name' %}{{ name }}, {% endfor %}"
     )
 
-    assert template.render() == ""  # noqa: PLC1901
+    assert template.render() == ""
 
     async def coro() -> str:
         return await template.render_async()
 
-    assert asyncio.run(coro()) == ""  # noqa: PLC1901
+    assert asyncio.run(coro()) == ""
 
 
 def test_target_string_raise_default() -> None:


### PR DESCRIPTION
This pull request fixes #1. 

~~As mentioned in https://github.com/jg-rp/python-jsonpath/issues/7, the lack of JSONPath expression traversal is blocking us from inspecting `FilterContextPath` instances within JSONPath filters, and therefor reporting those variables in static analysis results.~~

Even with JSONPath expression traversal (now implemented), we can't build a Liquid `Identifier` from a JSONPath statically.